### PR TITLE
fix: update neon market screen switcher labels

### DIFF
--- a/apps/web/app/concepts/neon-market/page.tsx
+++ b/apps/web/app/concepts/neon-market/page.tsx
@@ -252,7 +252,7 @@ function ScreenSwitcher({
 }) {
   return (
     <div className="flex flex-wrap gap-3">
-      {["Storefront", "Game Detail", "Lightning Checkout", "Receipt"].map((label, index) => {
+      {["STOREFRONT", "SELL YOUR GAME", "INFO FOR PLAYERS"].map((label, index) => {
         const screenIndex = index + 1;
         const isActive = activeScreen === screenIndex;
         return (


### PR DESCRIPTION
## Summary
- rename the Neon Market screen switcher buttons to STOREFRONT, SELL YOUR GAME, and INFO FOR PLAYERS so the copy matches the request

## Testing
- npm run lint:web

------
https://chatgpt.com/codex/tasks/task_e_68ce1f29ecdc832b90991c4076b9eba7